### PR TITLE
Allow NPM to detect the license

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "mocha",
     "bench": "node bench"
   },
+  "license": "MIT",
   "dependencies": {},
   "devDependencies": {
     "bench": "^0.3.6",


### PR DESCRIPTION
The license was not listed in the package.json and consequently shown on npmjs.org as 'none'.